### PR TITLE
remove thepath from the result if not ending with HOME anymore

### DIFF
--- a/src/PathForm.js
+++ b/src/PathForm.js
@@ -42,6 +42,10 @@ const PathForm = ({ sourceFarmer }) => {
         if (_.isEqual(adjacencyList[pathRoads[pathRoads.length - 1]], ['HOME'])) {
             setHomeEnding(true);
             setResult({ ...result, [sourceFarmer]: pathRoads.slice(1) });
+        } else {
+            const newResult = { ...result };
+            delete newResult[sourceFarmer];
+            setResult(newResult);
         }
     }, [pathRoads]);
 


### PR DESCRIPTION
Is there a one-liner for the removal as done in ``` setResult({ ...result, [sourceFarmer]: pathRoads.slice(1) })```?